### PR TITLE
charset needs to be declared

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>jinesh bhatt</title>
     <link rel="stylesheet" href="css/stylesheet.css">
+    <meta charset="utf-8">
     <script type="text/javascript">
       /*
       ___________________________


### PR DESCRIPTION
The following error shows up in Firefox: The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.